### PR TITLE
Fix hard limit of 5k results

### DIFF
--- a/dsquery.cs
+++ b/dsquery.cs
@@ -345,6 +345,7 @@ USAGE:
                 }
             }
             
+            searcher.PageSize = 1000;
             searcher.Filter = filter;
             
             // Set the limit, if applicable


### PR DESCRIPTION
No idea why, but you need to set a page size to retrieve all possible results - even if you specify no limit it was previously stopping at 5k results. Thanks Doug!