### PR TITLE
[Pull Request :: SharpUtils] Added CheckSign .NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Displays the computer's auditing policy (i.e., what actions will be logged)
 
 
 
+### check_sig.exe
+Displays if a file (EXE/DLL) has a Digital Signature, and Chain Information (if Available)
+
+#### Usage
+    check_sig.exe <full_path_to_exe_on_host> [/?]
+
+
+
 ### create_process.exe
 Uses WMI to execute a command on the specified remote host
 

--- a/check_sig.cs
+++ b/check_sig.cs
@@ -1,0 +1,98 @@
+// To Compile:
+//   C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /t:exe /out:check_sig.exe check_sig.cs
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+internal class CheckSign
+{
+    public static void PrintUsage()
+    {
+        Console.WriteLine(@"Check if EXE/DLL is signed. Returns Chain if available.
+        
+USAGE:
+    check_sig <full_path_to_exe/dll_on_host> [/?]");
+    }
+    private static void Main(string[] args)
+    {
+        try
+        {
+            // Check for Help
+            if (args.Length > 0 && args[0] == "/?")
+            {
+                //Print Usage
+                PrintUsage();
+                return;
+            }
+
+            // Check for Supplied File Argument
+            if (args == null || args.Length == 0 )
+            {
+                Console.WriteLine("[!] [CheckSign] No File Supplied");
+                return;
+            }
+
+            // Check if File was supplied
+            string filePath = args[0];
+            if (!File.Exists(filePath))
+            {
+                Console.WriteLine("[-] [CheckSign] File not found");
+                return;
+            }
+
+            // Check for Signature
+            X509Certificate2 theCertificate;
+            try
+            {
+                X509Certificate theSigner = X509Certificate.CreateFromSignedFile(filePath);
+                theCertificate = new X509Certificate2(theSigner);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("[-] [CheckSign] No digital signature found!");
+                Console.WriteLine("    [*] Message: " + ex.Message);
+                return;
+            }
+            
+            // Signature was Found, Gathering Chain information (if available).
+            // This will not reach out to the internet to verify validity, instead will check the local system.
+            bool chainIsValid = false;
+            var theCertificateChain = new X509Chain();
+            theCertificateChain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
+            theCertificateChain.ChainPolicy.RevocationMode = X509RevocationMode.Offline;
+            theCertificateChain.ChainPolicy.UrlRetrievalTimeout = new TimeSpan(0, 1, 0);
+            theCertificateChain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
+            chainIsValid = theCertificateChain.Build(theCertificate);
+
+            if (chainIsValid)
+            {
+                Console.WriteLine("[+] [CheckSign] Digital Signature Found!");
+                Console.WriteLine("    [*] Publisher Information : " + theCertificate.SubjectName.Name);
+                Console.WriteLine("    [*] Valid From: " + theCertificate.GetEffectiveDateString());
+                Console.WriteLine("    [*] Valid To: " + theCertificate.GetExpirationDateString());
+                Console.WriteLine("    [*] Issued By: " + theCertificate.Issuer);
+                return;
+            }
+            else
+            {
+                Console.WriteLine("[+] [CheckSign] Digital Signature Found!");
+                Console.WriteLine("    [-] Chain Not Valid or Unable to Verify Chain.");
+                Console.WriteLine("    [-] Certificate is/may be self-signed.");
+                return;
+            }
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine("[-] [CheckSign] ERROR: {0}", e.Message.Trim());
+        }
+        finally
+        {
+            Console.WriteLine("\nDONE");
+        }
+    }
+}

--- a/check_sig.cs
+++ b/check_sig.cs
@@ -18,6 +18,7 @@ internal class CheckSign
 USAGE:
     check_sig <full_path_to_exe/dll_on_host> [/?]");
     }
+	
     private static void Main(string[] args)
     {
         try
@@ -38,7 +39,8 @@ USAGE:
             }
 
             // Check if File was supplied
-            string filePath = args[0];
+            string filePath = string.Join(" ", args);
+			Console.WriteLine("[+] [CheckSign] " + filePath);
             if (!File.Exists(filePath))
             {
                 Console.WriteLine("[-] [CheckSign] File not found");

--- a/make.ps1
+++ b/make.ps1
@@ -13,6 +13,9 @@ C:\Windows\Microsoft.NET\Framework\v2.0.50727\csc.exe /t:exe /out:bin\auditpol_2
 C:\Windows\Microsoft.NET\Framework\v3.5\csc.exe /t:exe /out:bin\auditpol_3.5.exe auditpol.cs | Select-String error
 C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /t:exe /out:bin\auditpol_4.0.exe auditpol.cs | Select-String error
 
+Write-Output "  [*] check_sig.exe"
+C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /t:exe /out:bin\check_sig_4.0.exe check_sig.cs | Select-String error
+
 Write-Output "  [*] create_process.exe"
 C:\Windows\Microsoft.NET\Framework\v3.5\csc.exe /t:exe /out:bin\create_process_3.5.exe create_process.cs | Select-String error
 C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /t:exe /out:bin\create_process_4.0.exe create_process.cs | Select-String error


### PR DESCRIPTION
Updated and Tested CheckSign. (Tested on CMD and CobaltStrike, with files that do not have spaces and with files that do have spaces). CheckSign is intended to check if a target file contains a signature, and will test against the local machine if the certificate chain is valid. (This is only done locally, as I opted out to have it reach to microsoft to check validity). If the Binary is signed but validity cannot be verified, the tool will inform you that it is signed but could not be verified. Otherwise if its not signed, it will inform you, as it will not be able to find the requested object. 
Requesting to add to SharpUtils.